### PR TITLE
Add i18n support and french translations

### DIFF
--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -261,7 +261,7 @@ view model =
     , body =
         case model.state of
             Remapping remapModel ->
-                [ Gamepad.remapView controlsToMap model.userMappings remapModel |> Html.map OnRemapMsg
+                [ Gamepad.remapView controlsToMap model.userMappings remapModel Nothing |> Html.map OnRemapMsg
                 , div [] []
                 , div [] []
                 , button [ Html.Events.onClick OnToggleRemap ] [ text "Close Remap Tool" ]

--- a/src/Gamepad/I18n.elm
+++ b/src/Gamepad/I18n.elm
@@ -46,9 +46,15 @@ translations : Dict String Translations
 translations =
     Dict.fromList
         [ ( "en", en )
+        , ( "en_us", en )
         , ( "en_US", en )
+        , ( "en-us", en )
+        , ( "en-US", en )
         , ( "fr", fr )
+        , ( "fr_fr", fr )
         , ( "fr_FR", fr )
+        , ( "fr-fr", fr )
+        , ( "fr-FR", fr )
         ]
 
 

--- a/src/Gamepad/I18n.elm
+++ b/src/Gamepad/I18n.elm
@@ -1,4 +1,6 @@
-module Gamepad.I18n exposing (Lang(..), Translations, getLocale)
+module Gamepad.I18n exposing (Translations, translations, en, fr)
+
+import Dict exposing (Dict)
 
 
 type alias Translations =
@@ -19,44 +21,49 @@ type alias Translations =
     }
 
 
-type Lang
-    = En
-    | Fr
+translations : Dict String Translations
+translations =
+    Dict.fromList
+        [ ( "en", en )
+        , ( "en_US", en )
+        , ( "fr", fr )
+        , ( "fr_FR", fr )
+        ]
 
 
-getLocale : Lang -> Translations
-getLocale lang =
-    case lang of
-        En ->
-            { noGamepadsDetected = "No gamepads detected"
-            , remappingGamepadComplete = \id -> "Remapping Gamepad " ++ String.fromInt id ++ " complete."
-            , pressAnyButtonToGoBack = "Press any button to go back."
-            , remappingGamepad = \id -> "Remapping Gamepad " ++ String.fromInt id
-            , press = "Press:"
-            , skipThisAction = "Skip this action"
-            , cancelRemapping = "Cancel remapping"
-            , map = "Map"
-            , needsMapping = "Needs mapping"
-            , idle = "idle"
-            , receivingSignal = "Receiving signal"
-            , remap = "Remap"
-            , standardMapping = "Standard mapping"
-            , customMapping = "Custom mapping"
-            }
+en : Translations
+en =
+    { noGamepadsDetected = "No gamepads detected"
+    , remappingGamepadComplete = \id -> "Remapping Gamepad " ++ String.fromInt id ++ " complete."
+    , pressAnyButtonToGoBack = "Press any button to go back."
+    , remappingGamepad = \id -> "Remapping Gamepad " ++ String.fromInt id
+    , press = "Press:"
+    , skipThisAction = "Skip this action"
+    , cancelRemapping = "Cancel remapping"
+    , map = "Map"
+    , needsMapping = "Needs mapping"
+    , idle = "idle"
+    , receivingSignal = "Receiving signal"
+    , remap = "Remap"
+    , standardMapping = "Standard mapping"
+    , customMapping = "Custom mapping"
+    }
 
-        Fr ->
-            { noGamepadsDetected = "Aucune manette détectée"
-            , remappingGamepadComplete = \id -> "Configuration de la manette " ++ String.fromInt id ++ " terminée."
-            , pressAnyButtonToGoBack = "Pressez n'importe quelle touche pour revenir en arrière."
-            , remappingGamepad = \id -> "Configuration de la manette " ++ String.fromInt id
-            , press = "Pressez :"
-            , skipThisAction = "Passer cette action"
-            , cancelRemapping = "Annuler la configuration"
-            , map = "Attribuer"
-            , needsMapping = "Configuration nécessaire"
-            , idle = "inactif"
-            , receivingSignal = "Réception d'un signal"
-            , remap = "Configurer"
-            , standardMapping = "Configuration standard"
-            , customMapping = "Configuration personnalisée"
-            }
+
+fr : Translations
+fr =
+    { noGamepadsDetected = "Aucune manette détectée"
+    , remappingGamepadComplete = \id -> "Configuration de la manette " ++ String.fromInt id ++ " terminée."
+    , pressAnyButtonToGoBack = "Pressez n'importe quelle touche pour revenir en arrière."
+    , remappingGamepad = \id -> "Configuration de la manette " ++ String.fromInt id
+    , press = "Pressez :"
+    , skipThisAction = "Passer cette action"
+    , cancelRemapping = "Annuler la configuration"
+    , map = "Attribuer"
+    , needsMapping = "Configuration nécessaire"
+    , idle = "inactif"
+    , receivingSignal = "Réception d'un signal"
+    , remap = "Configurer"
+    , standardMapping = "Configuration standard"
+    , customMapping = "Configuration personnalisée"
+    }

--- a/src/Gamepad/I18n.elm
+++ b/src/Gamepad/I18n.elm
@@ -1,0 +1,62 @@
+module Gamepad.I18n exposing (Lang(..), Translations, getLocale)
+
+
+type alias Translations =
+    { noGamepadsDetected : String
+    , remappingGamepadComplete : Int -> String
+    , pressAnyButtonToGoBack : String
+    , remappingGamepad : Int -> String
+    , press : String
+    , skipThisAction : String
+    , cancelRemapping : String
+    , map : String
+    , needsMapping : String
+    , idle : String
+    , receivingSignal : String
+    , remap : String
+    , standardMapping : String
+    , customMapping : String
+    }
+
+
+type Lang
+    = En
+    | Fr
+
+
+getLocale : Lang -> Translations
+getLocale lang =
+    case lang of
+        En ->
+            { noGamepadsDetected = "No gamepads detected"
+            , remappingGamepadComplete = \id -> "Remapping Gamepad " ++ String.fromInt id ++ " complete."
+            , pressAnyButtonToGoBack = "Press any button to go back."
+            , remappingGamepad = \id -> "Remapping Gamepad " ++ String.fromInt id
+            , press = "Press:"
+            , skipThisAction = "Skip this action"
+            , cancelRemapping = "Cancel remapping"
+            , map = "Map"
+            , needsMapping = "Needs mapping"
+            , idle = "idle"
+            , receivingSignal = "Receiving signal"
+            , remap = "Remap"
+            , standardMapping = "Standard mapping"
+            , customMapping = "Custom mapping"
+            }
+
+        Fr ->
+            { noGamepadsDetected = "Aucune manette détectée"
+            , remappingGamepadComplete = \id -> "Configuration de la manette " ++ String.fromInt id ++ " terminée."
+            , pressAnyButtonToGoBack = "Pressez n'importe quelle touche pour revenir en arrière."
+            , remappingGamepad = \id -> "Configuration de la manette " ++ String.fromInt id
+            , press = "Pressez :"
+            , skipThisAction = "Passer cette action"
+            , cancelRemapping = "Annuler la configuration"
+            , map = "Attribuer"
+            , needsMapping = "Configuration nécessaire"
+            , idle = "inactif"
+            , receivingSignal = "Réception d'un signal"
+            , remap = "Configurer"
+            , standardMapping = "Configuration standard"
+            , customMapping = "Configuration personnalisée"
+            }

--- a/src/Gamepad/I18n.elm
+++ b/src/Gamepad/I18n.elm
@@ -1,8 +1,27 @@
-module Gamepad.I18n exposing (Translations, translations, en, fr)
+module Gamepad.I18n exposing
+    ( Translations, translations
+    , en, fr
+    )
+
+{-|
+
+
+# Translations
+
+@docs Translations, translations
+
+
+# Locales
+
+@docs en, fr
+
+-}
 
 import Dict exposing (Dict)
 
 
+{-| Messages in the remapView
+-}
 type alias Translations =
     { noGamepadsDetected : String
     , remappingGamepadComplete : Int -> String
@@ -21,6 +40,8 @@ type alias Translations =
     }
 
 
+{-| Locales provided by this package, indexed by language code (for example "en") compatible with codes provided by `navigator.language` on the javascript side.
+-}
 translations : Dict String Translations
 translations =
     Dict.fromList


### PR DESCRIPTION
Fixes #35.

Instead of adding a view function taking custom translations I opted to add a `trans : Translations` field in `RemapModel` with setter function to edit that field. Users can either select one of the included locales or provide their own translations. Please let me know you'd like this to be done differently.

Changes:
* Extracted messages from views into a data structure stored in the `RemapModel` (defaults to english).
* Added french translation.
* Added a configuration to change the current locale: `setRemapLang`.
* Added a configuration to set custom translation: `setRemapTranslations`.